### PR TITLE
wayvr-dashboard: add pulseaudio, use same deps as source repo

### DIFF
--- a/pkgs/by-name/wa/wayvr-dashboard/package.nix
+++ b/pkgs/by-name/wa/wayvr-dashboard/package.nix
@@ -15,6 +15,7 @@
   wrapGAppsHook4,
   librsvg,
   openssl,
+  pulseaudio,
 
   xrSources,
 }:
@@ -72,6 +73,12 @@ rustPlatform.buildRustPackage {
   preBuild = ''
     # using sass-embedded fails at executing node_modules/sass-embedded-linux-x64/dart-sass/src/dart
     rm -r node_modules/sass-embedded*
+  '';
+
+  postInstall = ''
+    gappsWrapperArgs+=(
+      --prefix PATH : "${lib.makeBinPath [ pulseaudio ]}}"
+    )
   '';
 
   inherit cargoRoot;

--- a/pkgs/by-name/wa/wayvr-dashboard/package.nix
+++ b/pkgs/by-name/wa/wayvr-dashboard/package.nix
@@ -9,11 +9,12 @@
   cargo-tauri,
   nodejs,
   glib,
-  gtk3,
-  gtk4,
+  gdk-pixbuf,
   webkitgtk_4_1,
-  libsoup_3,
   alsa-lib,
+  wrapGAppsHook4,
+  librsvg,
+  openssl,
 
   xrSources,
 }:
@@ -54,14 +55,17 @@ rustPlatform.buildRustPackage {
 
     nodejs
     importNpmLock.npmConfigHook
+
+    wrapGAppsHook4
   ];
 
   buildInputs = [
-    glib
-    gtk3
-    gtk4
     webkitgtk_4_1
-    libsoup_3
+    glib
+    gdk-pixbuf
+    librsvg
+
+    openssl
     alsa-lib
   ];
 


### PR DESCRIPTION
This adds pulseaudio for the audio control in the dashboard and makes sure to use the dependencies listed in the github action and `deb_to_appimage.sh` script of the [wayvr-dashboard](https://github.com/olekolek1000/wayvr-dashboard)

I haven't been able to fix the transparent screen issue yet and am honestly kind of lost on that one