### PR TITLE
wlx-overlay-s: remove stale Cargo.toml substitution

### DIFF
--- a/pkgs/overrides/wlx-overlay-s.nix
+++ b/pkgs/overrides/wlx-overlay-s.nix
@@ -14,12 +14,5 @@ final: prev: {
         libGL
         wayland
       ]);
-
-    postPatch =
-      prevAttrs.postPatch
-      + ''
-        substituteInPlace Cargo.toml \
-          --replace-fail \"static\", \"linked\",
-      '';
   });
 }


### PR DESCRIPTION
wlx-overlay-s has switched back to dynamically linked openxr-loader in https://github.com/galister/wlx-overlay-s/commit/9c0fd4ec21995af1d92b8b81ca3a55d372db707d