### PR TITLE
eepyxr: switch to ReleaseFast optimisations

### DIFF
--- a/pkgs/by-name/ee/eepyxr/package.nix
+++ b/pkgs/by-name/ee/eepyxr/package.nix
@@ -46,7 +46,7 @@ stdenv.mkDerivation {
   '';
 
   dontUseZigCheck = true;
-  zigBuildFlags = [ "-Doptimize=ReleaseSafe" ];
+  zigBuildFlags = [ "-Doptimize=ReleaseFast" ];
 
   meta = with lib; {
     description = "A Linux OpenXR overlay to help you sleep in VR";


### PR DESCRIPTION
Disables the debug log flood every frame.