### PR TITLE
proton-ge-rtsp-bin: GE-Proton9-22-rtsp17-1 -> GE-Proton10-15-rtsp18

### DIFF
--- a/pkgs/by-name/pr/proton-ge-rtsp-bin/package.nix
+++ b/pkgs/by-name/pr/proton-ge-rtsp-bin/package.nix
@@ -12,11 +12,11 @@
   (
     finalAttrs: _: {
       pname = "proton-ge-rtsp-bin";
-      version = "GE-Proton9-22-rtsp17-1";
+      version = "GE-Proton10-15-rtsp18";
 
       src = fetchzip {
         url = "https://github.com/SpookySkeletons/proton-ge-rtsp/releases/download/${finalAttrs.version}/${finalAttrs.version}.tar.gz";
-        hash = "sha256-GeExWNW0J3Nfq5rcBGiG2BNEmBg0s6bavF68QqJfuX8=";
+        hash = "sha256-sz/HyH/WLZNIpTushlpsuINyWw+QcxaHXdAcSKrTCBk=";
       };
 
       meta = {


### PR DESCRIPTION
Updates `proton-ge-rtsp-bin` to the new version of GE-Proton RTSP, deemed stable by SpookySkeletons
https://github.com/SpookySkeletons/proton-ge-rtsp/releases/tag/GE-Proton10-15-rtsp18