### PR TITLE
Fix lovr's glslang to build with GCC 15

### DIFF
--- a/pkgs/by-name/lo/lovr/package.nix
+++ b/pkgs/by-name/lo/lovr/package.nix
@@ -89,6 +89,12 @@ stdenv.mkDerivation (finalAttrs: {
     (lib.cmakeBool "LOVR_BUILD_BUNDLE" true)
   ];
 
+  # This is due to the upgrade of GCC to GCC 15, glslang needs to be upgraded in nixpkgs
+  # https://github.com/NixOS/nixpkgs/pull/469269
+  preBuild = ''
+    sed -e '1i #include <cstdint>' -i /build/lovr/deps/glslang/SPIRV/SpvBuilder.h
+  '';
+
   installPhase = ''
     runHook preInstall
 


### PR DESCRIPTION
As per https://github.com/NixOS/nixpkgs/issues/475479 which helps describe the potential issues introduced with the upgrade to GCC 15. This fixes the build for glslang 16.0.0 which can't be patched as its a git submodule.