### PR TITLE
proton-ge-rtsp-bin: GE-Proton10-33-rtsp23-1 -> GE-Proton10-33-rtsp23-3

### DIFF
--- a/pkgs/by-name/pr/proton-ge-rtsp-bin/package.nix
+++ b/pkgs/by-name/pr/proton-ge-rtsp-bin/package.nix
@@ -12,11 +12,11 @@
   (
     finalAttrs: _: {
       pname = "proton-ge-rtsp-bin";
-      version = "GE-Proton10-33-rtsp23-1";
+      version = "GE-Proton10-33-rtsp23-3";
 
       src = fetchzip {
         url = "https://github.com/SpookySkeletons/proton-ge-rtsp/releases/download/${finalAttrs.version}/${finalAttrs.version}.tar.gz";
-        hash = "sha256-gb/d28Lmz4r5Cetp7ct2eQtQZIAcMDxY4F3XCtLk3BY=";
+        hash = "sha256-f9rLihWMiyzUimHysi5bgEjHNSku1qdo4hgYsy7SzDY=";
       };
 
       preFixup = ''


### PR DESCRIPTION
As says in title. Also see [GE-Proton10-33-rtsp23-2](https://github.com/SpookySkeletons/proton-ge-rtsp/releases/tag/GE-Proton10-33-rtsp23-2).