### PR TITLE
proton-ge-rtsp-bin: GE-Proton10-33-rtsp23-3 -> GE-Proton10-33-rtsp23-4

### DIFF
--- a/pkgs/by-name/pr/proton-ge-rtsp-bin/package.nix
+++ b/pkgs/by-name/pr/proton-ge-rtsp-bin/package.nix
@@ -12,11 +12,11 @@
   (
     finalAttrs: _: {
       pname = "proton-ge-rtsp-bin";
-      version = "GE-Proton10-33-rtsp23-3";
+      version = "GE-Proton10-33-rtsp23-4";
 
       src = fetchzip {
         url = "https://github.com/SpookySkeletons/proton-ge-rtsp/releases/download/${finalAttrs.version}/${finalAttrs.version}.tar.gz";
-        hash = "sha256-f9rLihWMiyzUimHysi5bgEjHNSku1qdo4hgYsy7SzDY=";
+        hash = "sha256-sP+xNPbeI1jbs081QvFmj48A/yG6IC9ZPZRvGkFZnX0=";
       };
 
       preFixup = ''


### PR DESCRIPTION
As says in tittle.

Note that while [24-1 is out](https://github.com/SpookySkeletons/proton-ge-rtsp/releases/tag/GE-Proton10-33-rtsp24-1), it says to preferably not package it.