### PR TITLE
proton-rtsp-bin: init at proton-rtsp-11.0-20260609-1

### DIFF
--- a/README.md
+++ b/README.md
@@ -120,6 +120,7 @@ This overlay provides the following packages:
 - `opencomposite-vendored`
 - `oscavmgr`
 - `proton-ge-rtsp-bin`
+- `proton-rtsp-bin`
 - `resolute`
 - `vapor`
 - `wayvr`

--- a/pkgs/by-name/pr/proton-ge-rtsp-bin/package.nix
+++ b/pkgs/by-name/pr/proton-ge-rtsp-bin/package.nix
@@ -1,4 +1,6 @@
 # SPDX-FileCopyrightText: 2024 Sefa Eyeoglu <contact@scrumplex.net>
+# SPDX-FileCopyrightText: 2025 Sefa Eyeoglu <contact@scrumplex.net>
+# SPDX-FileCopyrightText: 2026 Sefa Eyeoglu <contact@scrumplex.net>
 #
 # SPDX-License-Identifier: MIT
 {
@@ -6,8 +8,11 @@
   lib,
   proton-ge-bin,
 }:
-(proton-ge-bin.override {
+let
   steamDisplayName = "GE-Proton-rtsp";
+in
+(proton-ge-bin.override {
+  inherit steamDisplayName;
 }).overrideAttrs
   (
     finalAttrs: _: {
@@ -21,7 +26,7 @@
 
       preFixup = ''
         substituteInPlace "$steamcompattool/compatibilitytool.vdf" \
-          --replace-fail "${finalAttrs.version}" "GE-Proton-rtsp"
+          --replace-fail "${finalAttrs.version}" "${steamDisplayName}"
       '';
 
       meta = {
@@ -35,6 +40,7 @@
         maintainers = with lib.maintainers; [
           Scrumplex
           RTUnreal
+          coolGi
         ];
       };
     }

--- a/pkgs/by-name/pr/proton-rtsp-bin/package.nix
+++ b/pkgs/by-name/pr/proton-rtsp-bin/package.nix
@@ -1,0 +1,50 @@
+# SPDX-FileCopyrightText: 2024 Sefa Eyeoglu <contact@scrumplex.net>
+# SPDX-FileCopyrightText: 2025 Sefa Eyeoglu <contact@scrumplex.net>
+# SPDX-FileCopyrightText: 2026 Sefa Eyeoglu <contact@scrumplex.net>
+# SPDX-FileCopyrightText: 2026 coolGi <me@coolgi.dev>
+#
+# SPDX-License-Identifier: MIT
+{
+  fetchzip,
+  lib,
+  proton-ge-bin,
+}:
+let
+  steamDisplayName = "Proton-RTSP";
+in
+(proton-ge-bin.override {
+  inherit steamDisplayName;
+}).overrideAttrs
+  (
+    finalAttrs: _: {
+      pname = "proton-rtsp-bin";
+      version = "proton-rtsp-11.0-20260609-1";
+
+      src = fetchzip {
+        url = "https://github.com/SpookySkeletons/proton-ge-rtsp/releases/download/${finalAttrs.version}/${finalAttrs.version}.tar.gz";
+        hash = "sha256-/YrUjR/Ynb0clNpXSaSlfpnqJ76ZfTYP9LR/WHHCMgk=";
+      };
+
+      preFixup = ''
+        substituteInPlace "$steamcompattool/compatibilitytool.vdf" \
+          --replace-fail "${finalAttrs.version}" "${steamDisplayName}"
+      '';
+
+      meta = {
+        # These are generic enough to be included in non-GE Proton builds
+        inherit (proton-ge-bin.meta)
+          description
+          license
+          sourceProvenance
+          ;
+
+        homepage = "https://github.com/SpookySkeletons/proton-ge-rtsp";
+        maintainers = with lib.maintainers; [
+          Scrumplex
+          RTUnreal
+          coolGi
+        ];
+        platforms = [ "x86_64-linux" ];
+      };
+    }
+  )


### PR DESCRIPTION
See discussion at https://github.com/nix-community/nixpkgs-xr/pull/749#issuecomment-4832136080

Temporarily split off from the regular Proton **GE** RTSP until it is known the direction RTSP will take ( https://github.com/SpookySkeletons/proton-ge-rtsp/issues/22 ).\
I opted to just copy the original package as there is a chance the original will be removed, so there's no point on putting in extra effort to combine them.